### PR TITLE
Match on Partial Queue Names

### DIFF
--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -58,7 +58,11 @@ module Resque::Plugins
     def queue_depth_for(queuename)
       queue_depths = Resque::Plugins::TimedRoundRobin.configuration.queue_depths
 
-      queue_depths.fetch(queuename, DEFAULT_QUEUE_DEPTH)
+      key = queue_depths.keys.detect do |queue_key|
+        partial_qn = "#{queue_key.to_s}_"
+        queuename.to_s.start_with?(partial_qn)
+      end
+      queue_depths.fetch(key, DEFAULT_QUEUE_DEPTH)
     end
 
     def reserve_with_round_robin

--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -58,8 +58,8 @@ module Resque::Plugins
     def queue_depth_for(queuename)
       queue_depths = Resque::Plugins::TimedRoundRobin.configuration.queue_depths
 
-      key = queue_depths.keys.detect do |queue_key|
-        partial_qn = "#{queue_key.to_s}_"
+      key = queue_depths.keys.detect do |queue_prefix|
+        partial_qn = "#{queue_prefix.to_s}_"
         queuename.to_s.start_with?(partial_qn)
       end
       queue_depths.fetch(key, DEFAULT_QUEUE_DEPTH)

--- a/spec/timed-round-robin_spec.rb
+++ b/spec/timed-round-robin_spec.rb
@@ -61,7 +61,15 @@ describe "TimedRoundRobin" do
       end
 
       it 'returns the customized depth' do
-        expect(worker.queue_depth_for(:q1)).to eq(custom_depth)
+        expect(worker.queue_depth_for(:q1_)).to eq(custom_depth)
+      end
+
+      it 'returns the customized depth for a partial queue name match' do
+        Resque::Plugins::TimedRoundRobin.configure do |c|
+          c.queue_depths = { :q1 => custom_depth }
+        end
+
+        expect(worker.queue_depth_for(:q1_foobar)).to eq(custom_depth)
       end
 
       it 'returns the default depth for non-customized queues' do


### PR DESCRIPTION
Our sharded beehive queues will be named with the connector run ids so `conduit-shard-00_beehive_123` however the shard config will only have `conduit-shard-00` in it and that is all we want to match on