### PR TITLE
Override Resque::Worker.working 

### DIFF
--- a/lib/resque-timed-round-robin.rb
+++ b/lib/resque-timed-round-robin.rb
@@ -2,6 +2,7 @@ require 'resque'
 require 'resque/worker'
 require "resque/plugins/timed_round_robin/version"
 require 'resque/plugins/timed_round_robin/configuration'
+require 'resque/plugins/timed_round_robin/resque_worker'
 require "resque/plugins/timed_round_robin/timed_round_robin"
 
 Resque::Worker.send(:include, Resque::Plugins::TimedRoundRobin)

--- a/lib/resque/plugins/timed_round_robin/resque_worker.rb
+++ b/lib/resque/plugins/timed_round_robin/resque_worker.rb
@@ -1,0 +1,24 @@
+module Resque
+  class Worker
+    # Returns an array of all worker objects currently processing jobs.
+    def self.working
+      names = all
+      return [] unless names.any?
+
+      reportedly_working = data_store.working_keys(names)
+
+      reportedly_working.map do |key|
+        worker = find(key.sub("worker:", ''), :skip_exists => true)
+        worker.job = { 'queue' => key.split(':').last }
+        worker
+      end.compact
+    end
+  end
+
+  class DataStore
+    def working_keys(worker_ids)
+      redis_keys = worker_ids.map { |id| "worker:#{id}" }
+      redis_keys.select { |k| @redis.exists(k) }
+    end
+  end
+end


### PR DESCRIPTION
to use `exists` instead of `mapped_mget`.  `mapped_mget` uses the redis method [mget](https://redis.io/commands/mget) which will return the values for all the given keys and in our case those values can be very large since they are payloads which is why redis struggles with it. By changing it to exists we will merely check if the key has a value and if not it returns false.

![](https://media1.tenor.com/images/1fa7374ebef73384e07ed98eb570043b/tenor.gif?itemid=9296079)