### PR TITLE
Use Redis pipelining to batch requests

### DIFF
--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -38,7 +38,7 @@ module Resque::Plugins
     def queue_depth(queuename)
       busy_queues = Resque::Worker.working.map { |worker| worker.job["queue"] }.compact
       # find the queuename, count it.
-      busy_queues.select {|q| q == queuename }.size
+      busy_queues.select {|q| q.to_s == queuename.to_s }.size
     end
 
     def should_work_on_queue?(queuename)
@@ -55,6 +55,7 @@ module Resque::Plugins
     end
 
     DEFAULT_QUEUE_DEPTH = 0
+
     def queue_depth_for(queuename)
       queue_depths = Resque::Plugins::TimedRoundRobin.configuration.queue_depths
 


### PR DESCRIPTION
This might help make this check a little faster since we replaced an MGET call
with a bunch of separate EXISTS calls. Using pipelining means we don't have to
wait for each individual request/response cycle.

Also, ensure we are always using symbols when comparing queue names. The tests
I added weren't passing before making this tweak. We convert queue name to a
symbol elsewhere but we weren't doing so here.