### PR TITLE
Use Exists Call for Queue Depth Checks with Pipelining 

### DIFF
--- a/lib/resque-timed-round-robin.rb
+++ b/lib/resque-timed-round-robin.rb
@@ -2,6 +2,7 @@ require 'resque'
 require 'resque/worker'
 require "resque/plugins/timed_round_robin/version"
 require 'resque/plugins/timed_round_robin/configuration'
+require 'resque/plugins/timed_round_robin/resque_worker'
 require "resque/plugins/timed_round_robin/timed_round_robin"
 
 Resque::Worker.send(:include, Resque::Plugins::TimedRoundRobin)

--- a/lib/resque/plugins/timed_round_robin/resque_worker.rb
+++ b/lib/resque/plugins/timed_round_robin/resque_worker.rb
@@ -1,0 +1,24 @@
+module Resque
+  class Worker
+    # Returns an array of all worker objects currently processing jobs.
+    def self.working
+      names = all
+      return [] unless names.any?
+
+      reportedly_working = data_store.working_keys(names)
+
+      reportedly_working.map do |key|
+        worker = find(key.sub("worker:", ''), :skip_exists => true)
+        worker.job = { 'queue' => key.split(':').last }
+        worker
+      end.compact
+    end
+  end
+
+  class DataStore
+    def working_keys(worker_ids)
+      redis_keys = worker_ids.map { |id| "worker:#{id}" }
+      redis_keys.select { |k| @redis.exists(k) }
+    end
+  end
+end

--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -38,7 +38,7 @@ module Resque::Plugins
     def queue_depth(queuename)
       busy_queues = Resque::Worker.working.map { |worker| worker.job["queue"] }.compact
       # find the queuename, count it.
-      busy_queues.select {|q| q == queuename }.size
+      busy_queues.select {|q| q.to_s == queuename.to_s }.size
     end
 
     def should_work_on_queue?(queuename)
@@ -55,6 +55,7 @@ module Resque::Plugins
     end
 
     DEFAULT_QUEUE_DEPTH = 0
+
     def queue_depth_for(queuename)
       queue_depths = Resque::Plugins::TimedRoundRobin.configuration.queue_depths
 


### PR DESCRIPTION
This call will return 10 times faster than mget or issuing `exists` inline. 

![](https://thumbs.gfycat.com/GlamorousDearestCygnet-size_restricted.gif)