### PR TITLE
Only Refresh the Queue List when a Slice Expires SRE-851 

### DIFF
--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -6,13 +6,15 @@ module Resque::Plugins
     end
 
     def rotated_queues
-      # Grab the current list of queues.  Don't cache it beyond this method call
-      # because queues can be added/removed dynamically
-      @rtrr_queues = queues
+      # only refresh queues when a slice expires
+      @rtrr_queues ||= queues
       return [] if @rtrr_queues.empty?
 
       @n ||= 0
-      advance_offset if slice_expired?
+      if slice_expired?
+        advance_offset
+        @rtrr_queues = queues
+      end
 
       @rtrr_queues.rotate(@n)
     end

--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -12,8 +12,8 @@ module Resque::Plugins
 
       @n ||= 0
       if slice_expired?
-        advance_offset
         @rtrr_queues = queues
+        advance_offset
       end
 
       @rtrr_queues.rotate(@n)


### PR DESCRIPTION
Rather than grabbing a new queue list for every single pass lets only grab a fresh queue list when a slice expires. We wont start on a new queue anyways until a slice expires so there is no need to fetch a new queue before then. This will cut down on our `Resque.queues` requests which are currently slamming redis overnight. 

![](https://media.giphy.com/media/l41lPcBHUwrz78LUA/giphy.gif)

JIRA: https://kennasecurity.atlassian.net/browse/SRE-851 