### PR TITLE
Reset Queues To Nil When None Are Present SRE-851

### DIFF
--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -8,7 +8,10 @@ module Resque::Plugins
     def rotated_queues
       # only refresh queues when a slice expires
       @rtrr_queues ||= queues
-      return [] if @rtrr_queues.empty?
+      if @rtrr_queues.empty?
+        @rtrr_queues = nil
+        return []
+      end
 
       @n ||= 0
       if slice_expired?

--- a/spec/timed-round-robin_spec.rb
+++ b/spec/timed-round-robin_spec.rb
@@ -58,6 +58,15 @@ describe "TimedRoundRobin" do
         worker.process
       end
     end
+
+    it "will check for new queues until it has some" do
+      worker = Resque::Worker.new('*')
+      worker.process
+      5.times { Resque::Job.create(:q1, SomeJob) }
+      worker.process
+
+      expect(Resque.size(:q1)).to eq 4
+    end
   end
 
   describe '#queue_depth' do


### PR DESCRIPTION
![](https://media3.giphy.com/media/3ohzdYJK1wAdPWVk88/source.gif)
We use wildcards rather than an explicit array of queues so if we have no queues to start make sure when we do we are checking for them

Failing Spec for old code:
```
Failures:

  1) TimedRoundRobin a worker will check for new queues until it has some
     Failure/Error: expect(Resque.size(:q1)).to eq 4

       expected: 4
            got: 5

       (compared using ==)
```

Successful all specs after new code
```
Mollys-MBP:resque-timed-round-robin mstruve$ be rspec spec/timed-round-robin_spec.rb
Starting redis for testing at localhost:9736...

Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.

Finished in 0.06495 seconds
12 examples, 0 failures

Randomized with seed 26435
```

JIRA: https://kennasecurity.atlassian.net/browse/SRE-851