### PR TITLE
Refresh queues after a queue has drained to avoid sitting on an empty…

### DIFF
--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -89,8 +89,9 @@ module Resque::Plugins
         job = reserve_job_from(queue)
         return job if job
 
-        # Start the next search at the queue after the one from which we pick a job.
+        # Move to the next queue if current one is empty and refresh the queue list
         @n += 1
+        @rtrr_queues = queues
       end
 
       nil


### PR DESCRIPTION
… queue when a new on is added

![](https://media1.tenor.com/images/089e145863534093e207827eafaba135/tenor.gif?itemid=8718727)