### PR TITLE
Refresh Resque Queue List At a Designated Interval SRE-822

### DIFF
--- a/lib/resque/plugins/timed_round_robin/configuration.rb
+++ b/lib/resque/plugins/timed_round_robin/configuration.rb
@@ -1,10 +1,11 @@
 module Resque::Plugins
   module TimedRoundRobin
     class Configuration
-      attr_accessor :queue_depths
+      attr_accessor :queue_depths, :queue_refresh_interval
 
       def initialize
         @queue_depths = {}
+        @queue_refresh_interval = 60
       end
     end
   end


### PR DESCRIPTION
Refresh queue list by a configured interval or every 60 seconds by default to cut down on Redis resque requests. I borked my dev box trying to find provision savings, currently in a full rebuild and then I will test this with a connector run. 

![](https://media.tenor.com/images/5ab5111c341b7e20ed8754e3d585ecfb/tenor.gif)

JIRA: https://kennasecurity.atlassian.net/browse/SRE-822

Passing Specs
```
Mollys-MacBook-Pro:resque-timed-round-robin mstruve$ be rspec spec/timed-round-robin_spec.rb
Starting redis for testing at localhost:9736...

Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.Passing 'flushall' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /Users/mstruve/.rvm/gems/ruby-2.4.0/gems/resque-1.27.4/lib/resque/data_store.rb:59:in `method_missing')
.

Finished in 0.07537 seconds
14 examples, 0 failures

Randomized with seed 4031
```