### PR TITLE
Oc 42 pause importer queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,13 @@ version: 2
 jobs:
   test:
     docker:
-      - image: quay.io/kennasecurity/ruby:2.5.5-ci
-        user: root
+      - image: circleci/ruby:2.5.5
       - image: redis:3.2.11
     steps:
       - checkout
       - run:
           name: Install Ruby gems
-          command: bundle install --path /opt/app/bundle
+          command: bundle install
       - run:
           name: Install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/lib/resque/plugins/timed_round_robin/configuration.rb
+++ b/lib/resque/plugins/timed_round_robin/configuration.rb
@@ -1,9 +1,10 @@
 module Resque::Plugins
   module TimedRoundRobin
     class Configuration
-      attr_accessor :queue_depths, :queue_refresh_interval
+      attr_accessor :paused_queues_set, :queue_depths, :queue_refresh_interval
 
       def initialize
+        @paused_queues_set = nil
         @queue_depths = {}
         @queue_refresh_interval = 60
       end

--- a/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
+++ b/lib/resque/plugins/timed_round_robin/timed_round_robin.rb
@@ -19,7 +19,13 @@ module Resque::Plugins
       return @rtrr_queues unless @rtrr_queues&.empty? || queue_list_expired?
       # refresh queues at a given interval, default is 60 seconds
       @queue_list_expiration = Time.now + queue_refresh_interval
-      queues
+      (queues || []) - paused_queues
+    end
+
+    def paused_queues
+      return [] if Resque::Plugins::TimedRoundRobin.configuration.paused_queues_set.nil?
+
+      data_store.smembers(Resque::Plugins::TimedRoundRobin.configuration.paused_queues_set)
     end
 
     def queue_list_expired?

--- a/lib/resque/plugins/timed_round_robin/version.rb
+++ b/lib/resque/plugins/timed_round_robin/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module TimedRoundRobin
-      VERSION = "0.1.4"
+      VERSION = "0.1.5"
     end
   end
 end

--- a/spec/timed-round-robin_spec.rb
+++ b/spec/timed-round-robin_spec.rb
@@ -99,6 +99,28 @@ describe "TimedRoundRobin" do
           end
         end
       end
+
+      context "when a queue has been paused" do
+        let(:paused_queue_set) { "custom_paused_queues" }
+
+        before do
+          Resque::Plugins::TimedRoundRobin.configure do |c|
+            c.paused_queues_set = paused_queue_set
+            c.queue_refresh_interval = 0
+          end
+
+          Resque.data_store.sadd(paused_queue_set, "q1")
+        end
+
+        it "excludes the paused queues" do
+          worker = Resque::Worker.new(:q1, :q2)
+
+          expect(worker).to receive(:queues).exactly(2).times { ["q2", "q2"] }
+
+          worker.process
+          worker.process
+        end
+      end
     end
   end
 


### PR DESCRIPTION
https://kennasecurity.atlassian.net/browse/OC-42

This PR adds the ability to pause worker processing on a particular queue without having to shutdown workers or kill the job completely.

Once the queue name has been added to the Redis set, workers should pickup the changes within the queue refresh interval (~60 seconds by default).

I had to tweak the CircleCI config due to the old image being removed.